### PR TITLE
Readme documentation still used UltraMapper instead of Mapper class name

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Would you still map it manually!?
 With UltraMapper you can solve this problem efficiently like this:
 
 ````c#
-UltraMapper ultraMapper = new UltraMapper();
+Mapper ultraMapper = new Mapper();
 Person clone = ultraMapper.Map<Person>( person );
 ````
 


### PR DESCRIPTION
Also, the source filename does not reflect the class name.