### PR TITLE
Allowing conditional member mapping

### DIFF
--- a/UltraMapper.Tests/ConditionalTests.cs
+++ b/UltraMapper.Tests/ConditionalTests.cs
@@ -1,0 +1,154 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+
+namespace UltraMapper.Tests
+{
+    public class DoMap
+    {
+        private DoChildMap _nested;
+        private List<DoChildMap> _children;
+        private int _count;
+        private int _collectionCount;
+
+        public int NestedGetCount => _count;
+
+        public bool UseNested { get; set; }
+
+        public DoChildMap Nested
+        {
+            get
+            {
+                _count++;
+                return _nested;
+            }
+            set => _nested = value;
+        }
+
+        public int NestedCollectionGetCount => _collectionCount;
+
+        public bool UseNestedCollection { get; set; }
+
+        public List<DoChildMap> NestedCollection
+        {
+            get
+            {
+                _collectionCount++;
+                return _children;
+            }
+            set => _children = value;
+        }
+    }
+
+    public class DoChildMap
+    {
+        public string MyName { get; set; }
+    }
+
+    [TestClass]
+    public class ConditionalTests
+    {
+        [TestMethod]
+        public void ConditionalMapSkippedSourceProp()
+        {
+            var source = new DoMap()
+            {
+                UseNested = false,
+                Nested = new DoChildMap()
+                {
+                    MyName = "bla"
+                }
+            };
+            var countBefore = source.NestedGetCount;
+            var target = ConfiguredMapper.Map<DoMap, DoMap>( source );
+            var countAfter = source.NestedGetCount;
+            Assert.IsNotNull( source.Nested, "source" );
+            Assert.IsNull( target.Nested, "target" );
+            Assert.AreEqual( countBefore, countAfter );
+        }
+
+        [TestMethod]
+        public void ConditionalMapNotSkippedSourceProp()
+        {
+            var source = new DoMap()
+            {
+                UseNested = true,
+                Nested = new DoChildMap()
+                {
+                    MyName = "bla"
+                }
+            };
+            var countBefore = source.NestedGetCount;
+            var target = ConfiguredMapper.Map<DoMap, DoMap>( source );
+            var countAfter = source.NestedGetCount;
+            Assert.IsNotNull( target.Nested, "target" );
+            Assert.IsNotNull( source.Nested, "source" );
+            Assert.AreEqual( countBefore + 1, countAfter );
+        }
+
+        [TestMethod]
+        public void ConditionalCollectionMapSkippedSourceProp()
+        {
+            var source = new DoMap()
+            {
+                UseNested = false,
+                Nested = new DoChildMap()
+                {
+                    MyName = "bla"
+                },
+                UseNestedCollection = false,
+                NestedCollection = new List<DoChildMap> {
+                    new DoChildMap() { MyName="kwuk1"} ,
+                    new DoChildMap() { MyName = "kwuk2" }
+                }
+            };
+            var countBefore = source.NestedCollectionGetCount;
+            var target = ConfiguredMapper.Map<DoMap, DoMap>( source );
+            var countAfter = source.NestedCollectionGetCount;
+            Assert.AreEqual( source.NestedCollection.Count, 2 );
+            Assert.AreEqual( target.NestedCollection.Count, 0 );
+            Assert.AreEqual( countBefore, countAfter );
+        }
+
+        [TestMethod]
+        public void ConditionalCollectionMapNotSkippedSourceProp()
+        {
+            var source = new DoMap()
+            {
+                UseNested = false,
+                Nested = new DoChildMap()
+                {
+                    MyName = "bla"
+                },
+                UseNestedCollection = true,
+                NestedCollection = new List<DoChildMap> {
+                    new DoChildMap() { MyName="kwuk1"} ,
+                    new DoChildMap() { MyName = "kwuk2" }
+                }
+            };
+            var countBefore = source.NestedCollectionGetCount;
+            var target = ConfiguredMapper.Map<DoMap, DoMap>( source );
+            var countAfter = source.NestedCollectionGetCount;
+            Assert.AreEqual( source.NestedCollection.Count, 2 );
+            Assert.AreEqual( target.NestedCollection.Count, 2 );
+            Assert.AreEqual( countBefore + 1, countAfter );
+        }
+
+        private Mapper ConfiguredMapper =>
+             new Mapper( cfg =>
+            {
+                cfg.MapTypes<DoMap, DoMap>()
+                   .MapConditionalMember(
+                        a => a.UseNested,
+                        () => null,
+                        a => a.Nested,
+                        t => t.Nested
+                   )
+                   .MapConditionalMember(
+                        a => a.UseNestedCollection,
+                        () => new List<DoChildMap>(),
+                        a => a.NestedCollection,
+                        t => t.NestedCollection
+                   );
+            } );
+    }
+}

--- a/UltraMapper/Configuration/Mapping/MappingPoints/MappingSource/ConditionalMappingSource.cs
+++ b/UltraMapper/Configuration/Mapping/MappingPoints/MappingSource/ConditionalMappingSource.cs
@@ -1,0 +1,18 @@
+﻿using System.Linq.Expressions;
+
+namespace UltraMapper.Internals
+{
+    public class ConditionalMappingSource : MappingSource
+    {
+        private readonly LambdaExpression _conditionalSourceGetter;
+
+        public ConditionalMappingSource(
+            LambdaExpression sourceMemberGetterExpression,
+            LambdaExpression conditionalSourceGetter ) : base( sourceMemberGetterExpression )
+        {
+            _conditionalSourceGetter = conditionalSourceGetter;
+        }
+
+        public override LambdaExpression ValueGetter => _conditionalSourceGetter;
+    }
+}

--- a/UltraMapper/Configuration/Mapping/MappingPoints/MappingSource/MappingSource.cs
+++ b/UltraMapper/Configuration/Mapping/MappingPoints/MappingSource/MappingSource.cs
@@ -4,9 +4,9 @@ using System.Reflection;
 
 namespace UltraMapper.Internals
 {
-    public sealed class MappingSource : MappingPoint, IMappingSource
+    public class MappingSource : MappingPoint, IMappingSource
     {
-        public LambdaExpression ValueGetter { get; }
+        public virtual LambdaExpression ValueGetter { get; }
 
         public MappingSource( Type type )
             : this( new MemberAccessPath( type ) ) { }

--- a/UltraMapper/Configuration/Mapping/TypeMapping.cs
+++ b/UltraMapper/Configuration/Mapping/TypeMapping.cs
@@ -17,12 +17,13 @@ namespace UltraMapper.Internals
         //Each source and target member is instantiated only once per typeMapping
         //so we can handle their options/configuration override correctly.
         private readonly Dictionary<MemberInfo, IMappingSource> _sources = new();
+
         private readonly Dictionary<MemberInfo, IMappingTarget> _targets = new();
 
         /*
          *A source member can be mapped to multiple target members.
          *
-         *A target member can be mapped just once and for that reason 
+         *A target member can be mapped just once and for that reason
          *multiple mappings override each other and the last one is used.
          *
          *The target member can be therefore used as the key of this dictionary
@@ -57,6 +58,7 @@ namespace UltraMapper.Internals
         }
 
         private bool? _isReferenceTrackingEnabled = null;
+
         public bool IsReferenceTrackingEnabled
         {
             get
@@ -74,6 +76,7 @@ namespace UltraMapper.Internals
         }
 
         private LambdaExpression _customConverter = null;
+
         public override LambdaExpression CustomConverter
         {
             get { return _customConverter; }
@@ -90,6 +93,7 @@ namespace UltraMapper.Internals
         }
 
         public bool? _ignoreMemberMappingResolvedByConvention = null;
+
         public bool? IgnoreMemberMappingResolvedByConvention
         {
             get
@@ -107,6 +111,7 @@ namespace UltraMapper.Internals
         }
 
         public ReferenceBehaviors _referenceBehavior = ReferenceBehaviors.INHERIT;
+
         public ReferenceBehaviors ReferenceBehavior
         {
             get
@@ -124,6 +129,7 @@ namespace UltraMapper.Internals
         }
 
         public CollectionBehaviors _collectionBehavior = CollectionBehaviors.INHERIT;
+
         public CollectionBehaviors CollectionBehavior
         {
             get
@@ -141,6 +147,7 @@ namespace UltraMapper.Internals
         }
 
         public LambdaExpression _collectionItemEqualityComparer;
+
         public LambdaExpression CollectionItemEqualityComparer
         {
             get
@@ -158,6 +165,7 @@ namespace UltraMapper.Internals
         }
 
         public LambdaExpression _customTargetConstructor;
+
         public LambdaExpression CustomTargetConstructor
         {
             get => _customTargetConstructor;
@@ -192,6 +200,17 @@ namespace UltraMapper.Internals
 
                    return mp;
                } );
+        }
+
+        public IMappingSource GetConditionalMappingSource(
+            MemberInfo sourceMember,
+            LambdaExpression sourceMemberGetterExpression,
+            LambdaExpression conditionalSourceGetter
+            )
+        {
+            // skip the original source and have a conditional one for this mapping
+            var conditionalSource = new ConditionalMappingSource( sourceMemberGetterExpression, conditionalSourceGetter );
+            return conditionalSource;
         }
 
         public IMappingTarget GetMappingTarget( MemberInfo targetMember,

--- a/UltraMapper/Internals/ExtensionMethods/DictionaryExtensions.cs
+++ b/UltraMapper/Internals/ExtensionMethods/DictionaryExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 
 namespace UltraMapper.Internals
 {
@@ -14,6 +15,14 @@ namespace UltraMapper.Internals
                 dictionary.Add( key, value );
             }
 
+            return value;
+        }
+
+        public static TValue OverWrite<TKey, TValue>(
+            this Dictionary<TKey, TValue> dictionary, TKey key, Func<TValue> valueFactory )
+        {
+            var value = valueFactory();
+            dictionary[ key ] = value;
             return value;
         }
     }

--- a/UltraMapper/UltraMapper.cs
+++ b/UltraMapper/UltraMapper.cs
@@ -87,7 +87,7 @@ namespace UltraMapper
             Type sourceType = source?.GetType() ?? typeof( TSource );
             Type targetType = target?.GetType() ?? typeof( TTarget );
 
-            if( this.Config.IsReferenceTrackingEnabled )               
+            if( this.Config.IsReferenceTrackingEnabled )
             {
                 if( referenceTracking == null )
                     referenceTracking = new ReferenceTracker();
@@ -98,12 +98,12 @@ namespace UltraMapper
             /*SINCE WE PASS AN EXISTING TARGET INSTANCE TO MAP ONTO
             *WE USE TO USE ALL OF THE EXISTING INSTANCES WE FOUND ON THE TARGET AS DEFAULT.
             *
-            *WE CAN DECIDE WETHER TO APPLY THIS REFERENCE BEHAVIOR GLOBALLY OR 
+            *WE CAN DECIDE WETHER TO APPLY THIS REFERENCE BEHAVIOR GLOBALLY OR
             *ON THE SPECIFIC MAPPING CONFIGURATION OF THE TYPE INVOLVED
             */
 
             var mapping = this.Config[ sourceType, targetType ];
-            mapping.ReferenceBehavior = refBehavior;                     
+            mapping.ReferenceBehavior = refBehavior;
 
             return this.Map( source, target, referenceTracking, mapping );
         }
@@ -222,18 +222,4 @@ namespace UltraMapper
             target = (TTarget)mapping.MappingFunc( referenceTracking, source, target );
         }
     }
-
-    //public partial class Mapper
-    //{
-    //    public object Map( object source, object target, ReferenceTracker referenceTracking = null )
-    //    {
-    //        var sourceType = source.GetType();
-    //        var targetType = target.GetType();
-
-    //        var mapping = this.MappingConfiguration[ sourceType, targetType ];
-    //        mapping.MappingFunc( referenceTracking, source, target );
-
-    //        return target;
-    //    }
-    //}
 }


### PR DESCRIPTION
The feature that I have been missing from this library is the posibillity to conditionally skip a mapping.
But not just in the converter part of the mapping,
Instead To have the posibillity to not even access the skipped member on the original object tree.

My use case:
Would like to be able to use ultramapper for mapping a source tree to a target tree.
But the source tree is Lazy loaded tree made up by NHibernate.
Accessing the members on the source tree does result in additional Database calls.
And the goal in the mapping is to Prune too large object trees before serialization, but then without accessing the
Source members to be skipped.

The working of this functionality is visible in class ConditionalTests.
I do understand that my implementation might by rudimentary and if you would like to implement this behavour that maybe you would
like to create a more mature implementation.