### PR TITLE
Fixing difficult collection mapping

### DIFF
--- a/UltraMapper.Tests/DifficultCollectionTests.cs
+++ b/UltraMapper.Tests/DifficultCollectionTests.cs
@@ -1,0 +1,143 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace UltraMapper.Tests
+{
+    [TestClass]
+    public class DifficultCollectionTests
+    {
+
+        [TestMethod]
+        public void CollectionItemsAndMembersSelfMapping()
+        {
+            var source = new Test { Users = Enumerable.Range( 0, 10 ).Select( x => new User { Id = x } ).ToList() };
+
+            var ultraMapper = new Mapper( cfg =>
+            {
+                cfg.MapTypes<Test, Test>()
+                 .MapMember( x => x.Users, y => y.Users,
+                    cfg2 =>
+                    {
+                        cfg2.SetCustomTargetConstructor( () => new List<User>() );
+                    }
+                 );
+                cfg.MapTypes<User, User>();
+            } );
+            var target = ultraMapper.Map<Test, Test>( source );
+            Assert.AreEqual( target.Users.Count, 10 );
+        }
+
+        [TestMethod]
+        public void CollectionItemsAndMembersMapping()
+        {
+            var source = new Test { Users = Enumerable.Range( 0, 10 ).Select( x => new User { Id = x } ).ToList() };
+
+            var ultraMapper = new Mapper( cfg =>
+            {
+                cfg.MapTypes<Test, TargetTest>()
+                    .MapMember( s => s.Users, t => t.UsersTarget,
+                    cfg2 =>
+                    {
+                        cfg2.SetCustomTargetConstructor( () => new List<TargetUser>() );
+                    } );
+                cfg.MapTypes<User, TargetUser>()
+                    .MapMember( s => s.Id, t => t.IdTarget );
+            } );
+            var target = ultraMapper.Map<Test, TargetTest>( source );
+            Assert.AreEqual( target.UsersTarget.Count, 10 );
+        }
+
+
+        public class User
+        {
+            public int Id { get; set; }
+        }
+
+        public class Test
+        {
+            public IList<User> Users { get; set; }
+            public bool ShouldMap { get; set; }
+        }
+
+        public class TargetUser
+        {
+            public int IdTarget { get; set; }
+        }
+
+        public class TargetTest
+        {
+            public IList<TargetUser> UsersTarget { get; set; }
+        }
+
+        private class ComplicatedIList<T> : IList<T>
+        {
+            private List<T> _child;
+
+            public static ComplicatedIList<T> MakeComplicatedList( IEnumerable<T> items )
+            {
+                return new ComplicatedIList<T>
+                {
+                    _child = items.ToList()
+                };
+            }
+
+            public T this[ int index ] { get => _child[ index ]; set => throw new System.NotImplementedException(); }
+
+            public int Count => _child.Count;
+
+            public bool IsReadOnly => false;
+
+            public void Add( T item )
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public void Clear()
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public bool Contains( T item )
+            {
+                return _child.Contains( item );
+            }
+
+            public void CopyTo( T[] array, int arrayIndex )
+            {
+                _child.CopyTo( array, arrayIndex );
+            }
+
+            public IEnumerator<T> GetEnumerator()
+            {
+                return _child.GetEnumerator();
+            }
+
+            public int IndexOf( T item )
+            {
+                return _child.IndexOf( item );
+            }
+
+            public void Insert( int index, T item )
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public bool Remove( T item )
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public void RemoveAt( int index )
+            {
+                throw new System.NotImplementedException();
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return _child.GetEnumerator();
+            }
+        }
+    }
+}

--- a/UltraMapper.Tests/DifficultCollectionTests.cs
+++ b/UltraMapper.Tests/DifficultCollectionTests.cs
@@ -21,6 +21,7 @@ namespace UltraMapper.Tests
                     cfg2 =>
                     {
                         cfg2.SetCustomTargetConstructor( () => new List<User>() );
+                        cfg2.SetCustomTargetInsertMethod<IList<User>, User>( ( t, item ) => t.Add( item ) );
                     }
                  );
                 cfg.MapTypes<User, User>();
@@ -41,6 +42,7 @@ namespace UltraMapper.Tests
                     cfg2 =>
                     {
                         cfg2.SetCustomTargetConstructor( () => new List<TargetUser>() );
+                        cfg2.SetCustomTargetInsertMethod<IList<TargetUser>, TargetUser>( ( t, item ) => t.Add( item ) );
                     } );
                 cfg.MapTypes<User, TargetUser>()
                     .MapMember( s => s.Id, t => t.IdTarget );
@@ -71,6 +73,12 @@ namespace UltraMapper.Tests
             public IList<TargetUser> UsersTarget { get; set; }
         }
 
+        /// <summary>
+        /// This class mimicks a complex collection whichs is created and managed by a framework. 
+        /// The class can not be easily created using default constructor.
+        /// Therefore in the mapping would like to map this to another implementation  of IList<typeparamref name="T"/>.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
         private class ComplicatedIList<T> : IList<T>
         {
             private List<T> _child;

--- a/UltraMapper/CodeGeneration/MappingExpressionBuilders/ReferenceTypes/CollectionTypes/CollectionMapperViaTempCollection.cs
+++ b/UltraMapper/CodeGeneration/MappingExpressionBuilders/ReferenceTypes/CollectionTypes/CollectionMapperViaTempCollection.cs
@@ -22,7 +22,7 @@ namespace UltraMapper.MappingExpressionBuilders
     //            return base.GetExpressionBody( contextObj );
 
     //        //1. Create a new temporary collection passing the source collection as input
-    //        //   AND/OR   
+    //        //   AND/OR
     //        //   Create a new temporary collection passing the target collection as input
 
     //        //2. Read items from the source temp collection and add items to the target collection
@@ -172,7 +172,7 @@ namespace UltraMapper.MappingExpressionBuilders
     //                //    ) : Expression.Empty(),
 
     //                //isUpdate ? GetUpdateCollectionExpression( context )
-    //                //    : 
+    //                //    :
     //                ComplexCollectionLoop
     //                (
     //                    tempSourceColl,
@@ -267,7 +267,6 @@ namespace UltraMapper.MappingExpressionBuilders
             var tempCollection = Expression.Parameter( tempCollectionType, "tempCollection" );
 
             var newTempCollectionExp = Expression.New( tempCollectionConstructorInfo, context.SourceInstance );
-            var tempCollectionInsertionMethod = this.GetTempCollectionInsertionMethod( context );
 
             bool isUpdate = context.Options.CollectionBehavior == CollectionBehaviors.UPDATE;
             bool isReset = context.Options.CollectionBehavior == CollectionBehaviors.RESET;
@@ -288,8 +287,8 @@ namespace UltraMapper.MappingExpressionBuilders
                         context.SourceCollectionElementType,
                         context.TargetInstance,
                         context.TargetCollectionElementType,
-                        tempCollectionInsertionMethod,
                         context.SourceCollectionLoopingVar,
+                        this.GetTempCollectionInsertionMethod,
                         context.Mapper,
                         context.ReferenceTracker,
                         context
@@ -310,8 +309,8 @@ namespace UltraMapper.MappingExpressionBuilders
                         context.SourceCollectionElementType,
                         context.TargetInstance,
                         context.TargetCollectionElementType,
-                        tempCollectionInsertionMethod,
                         context.SourceCollectionLoopingVar,
+                        this.GetTempCollectionInsertionMethod,
                         context.ReferenceTracker,
                         context.Mapper,
                         context

--- a/UltraMapper/CodeGeneration/MappingExpressionBuilders/ReferenceTypes/CollectionTypes/CollectionToArrayMapper.cs
+++ b/UltraMapper/CodeGeneration/MappingExpressionBuilders/ReferenceTypes/CollectionTypes/CollectionToArrayMapper.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -39,7 +38,8 @@ namespace UltraMapper.MappingExpressionBuilders
 
         protected override Expression SimpleCollectionLoop( ParameterExpression sourceCollection, Type sourceCollectionElementType,
             ParameterExpression targetCollection, Type targetCollectionElementType,
-            MethodInfo targetCollectionInsertionMethod, ParameterExpression sourceCollectionLoopingVar,
+            ParameterExpression sourceCollectionLoopingVar,
+            Func<CollectionMapperContext, MethodInfo> getInsertMethod,
             ParameterExpression mapper, ParameterExpression referenceTracker, CollectionMapperContext context )
         {
             var resizeExp = GetResizeExpression( sourceCollection, targetCollection, context );
@@ -103,11 +103,11 @@ namespace UltraMapper.MappingExpressionBuilders
         {
             var sourceCountMethod = GetCountMethod( sourceCollection.Type );
             var targetCountMethod = GetCountMethod( targetCollection.Type );
-            
+
             Expression sourceCountMethodCallExp;
             if( sourceCountMethod.IsStatic )
                 sourceCountMethodCallExp = Expression.Call( null, sourceCountMethod, sourceCollection );
-            else 
+            else
                 sourceCountMethodCallExp = Expression.Call( sourceCollection, sourceCountMethod );
 
             Expression targetCountMethodCallExp;
@@ -131,10 +131,10 @@ namespace UltraMapper.MappingExpressionBuilders
 
         protected override Expression ComplexCollectionLoop( ParameterExpression sourceCollection, Type sourceCollectionElementType,
             ParameterExpression targetCollection, Type targetCollectionElementType,
-            MethodInfo targetCollectionInsertionMethod, ParameterExpression sourceCollectionLoopingVar,
+            ParameterExpression sourceCollectionLoopingVar,
+            Func<CollectionMapperContext, MethodInfo> getInsertMethod,
             ParameterExpression referenceTracker, ParameterExpression mapper, CollectionMapperContext context = null )
         {
-
             var newElement = Expression.Variable( targetCollectionElementType, "newElement" );
             var itemIndex = Expression.Parameter( typeof( int ), "itemIndex" );
             var resizeExp = GetResizeExpression( sourceCollection, targetCollection, context );

--- a/UltraMapper/CodeGeneration/MappingExpressionBuilders/ReferenceTypes/CollectionTypes/ReadOnlyCollectionMapper.cs
+++ b/UltraMapper/CodeGeneration/MappingExpressionBuilders/ReferenceTypes/CollectionTypes/ReadOnlyCollectionMapper.cs
@@ -23,12 +23,12 @@ namespace UltraMapper.MappingExpressionBuilders
 
                 bool hasInputCollectionCtor = target.EntryType
                     .GetConstructors().FirstOrDefault( ctor =>
-                {
-                    var parameters = ctor.GetParameters();
-                    if( parameters.Length != 1 ) return false;
+                    {
+                        var parameters = ctor.GetParameters();
+                        if( parameters.Length != 1 ) return false;
 
-                    return parameters[ 0 ].ParameterType.IsEnumerable();
-                } ) != null;
+                        return parameters[ 0 ].ParameterType.IsEnumerable();
+                    } ) != null;
 
                 return hasInputCollectionCtor;
             } ).Value;
@@ -71,7 +71,6 @@ namespace UltraMapper.MappingExpressionBuilders
                 return parameters[ 0 ].ParameterType.IsEnumerable();
             } );
 
-            var temporaryCollectionInsertionMethod = this.GetTemporaryCollectionInsertionMethod( collectionContext );
             if( collectionContext.IsTargetElementTypeBuiltIn )
             {
                 return Expression.Block
@@ -85,10 +84,10 @@ namespace UltraMapper.MappingExpressionBuilders
                         collectionContext.SourceCollectionElementType,
                         tempCollection,
                         collectionContext.TargetCollectionElementType,
-                        temporaryCollectionInsertionMethod,
                         collectionContext.SourceCollectionLoopingVar,
+                        this.GetTemporaryCollectionInsertionMethod,
                         collectionContext.Mapper,
-                        collectionContext.ReferenceTracker, 
+                        collectionContext.ReferenceTracker,
                         collectionContext
                     ),
 
@@ -108,8 +107,8 @@ namespace UltraMapper.MappingExpressionBuilders
                     collectionContext.SourceCollectionElementType,
                     tempCollection,
                     collectionContext.TargetCollectionElementType,
-                    temporaryCollectionInsertionMethod,
                     collectionContext.SourceCollectionLoopingVar,
+                    this.GetTemporaryCollectionInsertionMethod,
                     context.ReferenceTracker,
                     context.Mapper,
                     collectionContext

--- a/UltraMapper/Configuration/Mapping/MemberMapping.cs
+++ b/UltraMapper/Configuration/Mapping/MemberMapping.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using UltraMapper.MappingExpressionBuilders;
@@ -202,7 +203,10 @@ namespace UltraMapper.Internals
                 return _memberMappingExpression;
             }
         }
+        public LambdaExpression CustomTargetInsertMethod { get; set; }
 
+        public void SetCustomTargetInsertMethod<TTarget, TItem>( Expression<Action<TTarget, TItem>> insert ) where TTarget : IEnumerable<TItem> =>
+                   CustomTargetInsertMethod = insert;
 
         public void SetCustomTargetConstructor<T>( Expression<Func<T>> ctor )
             => CustomTargetConstructor = ctor;

--- a/UltraMapper/Configuration/Mapping/TypeMapping.cs
+++ b/UltraMapper/Configuration/Mapping/TypeMapping.cs
@@ -167,6 +167,11 @@ namespace UltraMapper.Internals
         public void SetCustomTargetConstructor<T>( Expression<Func<T>> ctor )
             => CustomTargetConstructor = ctor;
 
+        public LambdaExpression CustomTargetInsertMethod { get; set; }
+
+        public void SetCustomTargetInsertMethod<TTarget, TItem>( Expression<Action<TTarget, TItem>> insert ) where TTarget : IEnumerable<TItem> =>
+                   CustomTargetInsertMethod = insert;
+
         public void SetCollectionItemEqualityComparer<TSource, TTarget>( Expression<Func<TSource, TTarget, bool>> converter )
             => CollectionItemEqualityComparer = converter;
 

--- a/UltraMapper/Configuration/Options/IMappingOptions.cs
+++ b/UltraMapper/Configuration/Options/IMappingOptions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq.Expressions;
 
 namespace UltraMapper
@@ -13,8 +14,10 @@ namespace UltraMapper
         LambdaExpression CollectionItemEqualityComparer { get; set; }
         LambdaExpression CustomTargetConstructor { get; set; }
         LambdaExpression CustomConverter { get; set; }
+        LambdaExpression CustomTargetInsertMethod { get; set; }
 
         void SetCustomTargetConstructor<T>( Expression<Func<T>> ctor );
+        void SetCustomTargetInsertMethod<TTarget, TItem>( Expression<Action<TTarget, TItem>> insert ) where TTarget : IEnumerable<TItem>;
         void SetCollectionItemEqualityComparer<TSource, TTarget>( Expression<Func<TSource, TTarget, bool>> converter );
     }
 }


### PR DESCRIPTION
With this fix we can use the mapping options to convert to a different implementation of the target collection interface.
This allows us to not having to need the same type of collection when that type is completely managed by another framework.
